### PR TITLE
fix: avoid invalid placeholder input

### DIFF
--- a/src/playstationAccessory.ts
+++ b/src/playstationAccessory.ts
@@ -113,9 +113,14 @@ export class PlaystationAccessory {
   }
 
   private setTitleList() {
-    // if nothing selected yet, add a placeholder
-    this.addTitleToList("CUSAXXXXXX", "---", 0);
     const titleList = this.platform.config.apps || [];
+
+    if (titleList.length === 0) {
+      return;
+    }
+
+    // if nothing selected yet, add a placeholder
+    this.addTitleToList("CUSAXXXXXX", "None", 0);
     titleList.forEach((title, index) => {
       this.log.debug(`Adding input for title: `, title);
       this.addTitleToList(title.id, title.name, index + 1);


### PR DESCRIPTION
## Summary
- Do not create input source services when no apps are configured.
- Rename the fallback input placeholder from `---` to `None` when app inputs are configured.

## Motivation
Fixes #152. The `---` placeholder violates HAP-NodeJS name validation and causes warnings on startup, especially for PS5 setups where app inputs are not configured/supported.

## Testing
- `npm run lint`
- `npm run build`