### PR TITLE
Consolidate dependency security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,23 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/@fastify/cors/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/deepmerge": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
@@ -283,9 +300,9 @@
       "license": "MIT"
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
-      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
       "dev": true,
       "funding": [
         {
@@ -299,7 +316,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-json-stringify": "^6.0.0"
+        "fast-json-stringify": "^7.0.0"
       }
     },
     "node_modules/@fastify/formbody": {
@@ -323,6 +340,23 @@
         "fastify-plugin": "^5.0.0"
       }
     },
+    "node_modules/@fastify/formbody/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/forwarded": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
@@ -341,9 +375,9 @@
       "license": "MIT"
     },
     "node_modules/@fastify/helmet": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
-      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.1.0.tgz",
+      "integrity": "sha512-SvVOU0IrzYJW1BvSkfq9G1WUdW3dnaRUvg6m0BtgGMBmML62No0VmSu087jecH58SFbicbREgZTPJ89mAguupA==",
       "dev": true,
       "funding": [
         {
@@ -357,7 +391,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fastify-plugin": "^5.0.0",
+        "fastify-plugin": "^6.0.0",
         "helmet": "^8.0.0"
       }
     },
@@ -382,9 +416,9 @@
       }
     },
     "node_modules/@fastify/multipart": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-10.0.0.tgz",
-      "integrity": "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-10.1.0.tgz",
+      "integrity": "sha512-b2r6CovmLQvLFJ5HJDtxVigZjcO9TwkRGslhiNQxsGJwilm5B3eqvXPOVLudC44zXMXJITpQ/iEATIE7zoXqcQ==",
       "dev": true,
       "funding": [
         {
@@ -401,7 +435,7 @@
         "@fastify/busboy": "^3.0.0",
         "@fastify/deepmerge": "^3.0.0",
         "@fastify/error": "^4.0.0",
-        "fastify-plugin": "^5.0.0",
+        "fastify-plugin": "^6.0.0",
         "secure-json-parse": "^4.0.0"
       }
     },
@@ -451,9 +485,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.3.0.tgz",
+      "integrity": "sha512-9YMYRpCOtMBrqKYWcqiw7ykOrn4D0jogHpJrFS0KGeSuOwzKMM5/mjj7B0CFLVoQ6htqKYw//Zs7APn9DBq05w==",
       "dev": true,
       "funding": [
         {
@@ -470,7 +504,7 @@
         "@fastify/accept-negotiator": "^2.0.0",
         "@fastify/send": "^4.0.0",
         "content-disposition": "^1.0.1",
-        "fastify-plugin": "^5.0.0",
+        "fastify-plugin": "^6.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
       }
@@ -567,14 +601,14 @@
       }
     },
     "node_modules/@homebridge/hap-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/hap-client/-/hap-client-5.0.0.tgz",
-      "integrity": "sha512-mvZGHEob1xgEIFaMIQ0Nxm4iIMY2+pl1/u5TwR0nExfF1FRjbFdL6rPePdwT3iwU1jRZHK3Cn7CLyFJw9/Z3FA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-client/-/hap-client-5.1.0.tgz",
+      "integrity": "sha512-zbwJDgoE92rZqcdkfkvwMmKjp417DCLllyvJqqAUjo7OQqFqcbSWQ3oRoP05IdJS//FBwUC1yyVYaSJLLn17Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "1.16.1",
-        "bonjour-service": "1.4.0",
+        "axios": "1.18.1",
+        "bonjour-service": "1.4.3",
         "decamelize": "6.0.1",
         "inflection": "3.0.2"
       }
@@ -828,9 +862,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.24",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.24.tgz",
-      "integrity": "sha512-9zHxaDDM+oXW9As6UsP5yYB+UqczBmpeSCIFWdPEtEukMnZhxODG1BBjaUcdBB8Sc1uzojSJSJlp3yFp853t1g==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
+      "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -860,14 +894,12 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.24",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.24.tgz",
-      "integrity": "sha512-K4bzT+lEdd0Hhcsw3jtk56QAW6s6skK3ViN7hIROSN0kUf4ROwWEAKopJID6yhPQxB45kDtP2wEcjzE8171J3g==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
+      "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
         "path-to-regexp": "8.4.2",
@@ -948,17 +980,17 @@
       }
     },
     "node_modules/@nestjs/platform-fastify": {
-      "version": "11.1.24",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-11.1.24.tgz",
-      "integrity": "sha512-AJAVZZKCLQcDkQipD+NfrmV69DoQRNnrE+EB0VBS7FEZRjsnNmkmZFDFnhl/JWgzm6rjxsI3Qdaj/0+VlgbfSg==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-11.1.28.tgz",
+      "integrity": "sha512-utUfyxRzZsoFxz1GU3Z0OthHpijB605iqtxwFnk9yKowLrU1t1ZkxMUuad/csemImY6AsuaTpTjCecKbmfl+pQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "11.2.0",
         "@fastify/formbody": "8.0.2",
         "fast-querystring": "1.1.2",
-        "fastify": "5.8.5",
-        "fastify-plugin": "5.1.0",
+        "fastify": "5.10.0",
+        "fastify-plugin": "6.0.0",
         "find-my-way": "9.6.0",
         "light-my-request": "6.6.0",
         "path-to-regexp": "8.4.2",
@@ -971,7 +1003,7 @@
       },
       "peerDependencies": {
         "@fastify/static": "^8.0.0 || ^9.0.0",
-        "@fastify/view": "^10.0.0 || ^11.0.0",
+        "@fastify/view": "^10.0.0 || ^11.0.0 || ^12.0.0",
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
       },
@@ -985,9 +1017,9 @@
       }
     },
     "node_modules/@nestjs/platform-socket.io": {
-      "version": "11.1.24",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.24.tgz",
-      "integrity": "sha512-ImdR9G8W5Y2Hhcptdci+tNaG6JV/dzDguFTgtXOL5ie/gD9O9ARw8Cd9RzF2+oteyzQ+1sPK/+wgVOPOyYGVCA==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.28.tgz",
+      "integrity": "sha512-vY+GmU2jBcymvgm5rEnftUx4qNxK8cDJmXjl1/1NcpITTNJo0vg07xYR43MwXHcMqe7b0jwqt5+UCTzxqQFIqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1005,21 +1037,21 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.4.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
-      "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+      "version": "11.4.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.6.tgz",
+      "integrity": "sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
         "@nestjs/mapped-types": "2.1.1",
-        "js-yaml": "4.1.1",
+        "js-yaml": "5.2.1",
         "lodash": "4.18.1",
         "path-to-regexp": "8.4.2",
-        "swagger-ui-dist": "5.32.6"
+        "swagger-ui-dist": "5.32.8"
       },
       "peerDependencies": {
-        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@fastify/static": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "class-transformer": "*",
@@ -1038,10 +1070,33 @@
         }
       }
     },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/@nestjs/websockets": {
-      "version": "11.1.24",
-      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.24.tgz",
-      "integrity": "sha512-37Z/QYzZ4nPHcGyGGjhjoKVOcpSPMhmRQj5DS1l0RKlRYgq8S0cmgaZ6kQ8PI3259PdchLx41oQibXh22iEUiA==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.28.tgz",
+      "integrity": "sha512-jeyclAURCJTN8S8lctDhfLdiJeDKjZmYWWLav653Fb9hl9c+zx5jPhavI8Xk5++R8u+lX9qzaRxtsjEoxTtjyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1127,23 +1182,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@nuxt/opencollective": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
-      "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      },
-      "bin": {
-        "opencollective": "bin/opencollective.js"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0",
-        "npm": ">=5.10.0"
       }
     },
     "node_modules/@otplib/core": {
@@ -1879,9 +1917,9 @@
       }
     },
     "node_modules/avvio": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
-      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
       "dev": true,
       "funding": [
         {
@@ -1900,9 +1938,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1998,9 +2036,9 @@
       }
     },
     "node_modules/bonjour-service": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
-      "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
+      "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2421,16 +2459,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -3244,9 +3272,9 @@
       "license": "MIT"
     },
     "node_modules/fast-json-stringify": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
-      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
       "dev": true,
       "funding": [
         {
@@ -3263,7 +3291,7 @@
         "@fastify/merge-json-schemas": "^0.2.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
-        "fast-uri": "^3.0.0",
+        "fast-uri": "^4.0.0",
         "json-schema-ref-resolver": "^3.0.0",
         "rfdc": "^1.2.0"
       }
@@ -3284,6 +3312,40 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3327,9 +3389,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3344,9 +3406,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
-      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
       "dev": true,
       "funding": [
         {
@@ -3366,8 +3428,8 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
@@ -3378,9 +3440,9 @@
       }
     },
     "node_modules/fastify-plugin": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
       "dev": true,
       "funding": [
         {
@@ -3557,17 +3619,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3908,9 +3970,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3921,13 +3983,16 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hexy": {
@@ -3967,9 +4032,9 @@
       }
     },
     "node_modules/homebridge-config-ui-x": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-5.24.0.tgz",
-      "integrity": "sha512-9JWoVv0mp22TCZy5t0wXscUr5hv68Q0qU2ofgSblNL461YkH7DFy32KKQCIgiIWHSpdaz1Iy0rV2AkN7OdFLhQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-5.27.0.tgz",
+      "integrity": "sha512-BlLvB5vOubvGumeEM/TUn2glHUAFFB/Zt1jSA7TtZPQZrFFgYAYMxeXSvXnGoA0vz1h+VHrUmOqFpItEqVYE2Q==",
       "dev": true,
       "funding": [
         {
@@ -3983,46 +4048,46 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@fastify/helmet": "13.0.2",
-        "@fastify/multipart": "10.0.0",
-        "@fastify/static": "9.1.3",
-        "@homebridge/hap-client": "5.0.0",
+        "@fastify/helmet": "13.1.0",
+        "@fastify/multipart": "10.1.0",
+        "@fastify/static": "9.3.0",
+        "@homebridge/hap-client": "5.1.0",
         "@homebridge/node-pty-prebuilt-multiarch": "0.13.1",
         "@nestjs/axios": "4.0.1",
-        "@nestjs/common": "11.1.24",
-        "@nestjs/core": "11.1.24",
+        "@nestjs/common": "11.1.28",
+        "@nestjs/core": "11.1.28",
         "@nestjs/jwt": "11.0.2",
         "@nestjs/passport": "11.0.5",
-        "@nestjs/platform-fastify": "11.1.24",
-        "@nestjs/platform-socket.io": "11.1.24",
-        "@nestjs/swagger": "11.4.4",
-        "@nestjs/websockets": "11.1.24",
-        "axios": "1.16.1",
+        "@nestjs/platform-fastify": "11.1.28",
+        "@nestjs/platform-socket.io": "11.1.28",
+        "@nestjs/swagger": "11.4.6",
+        "@nestjs/websockets": "11.1.28",
+        "axios": "1.18.1",
         "bash-color": "0.0.4",
-        "bonjour-service": "1.4.0",
+        "bonjour-service": "1.4.3",
         "class-transformer": "0.5.1",
         "class-validator": "0.15.1",
         "commander": "15.0.0",
         "dayjs": "1.11.21",
-        "fastify": "5.8.5",
-        "fs-extra": "11.3.5",
+        "fastify": "5.10.0",
+        "fs-extra": "11.3.6",
         "jsonwebtoken": "9.0.3",
         "node-cache": "5.1.2",
         "node-forge": "1.4.0",
         "node-schedule": "2.1.1",
-        "ora": "9.4.0",
+        "ora": "9.4.1",
         "otplib": "13.4.1",
         "p-limit": "7.3.0",
         "passport": "0.7.0",
         "passport-jwt": "4.0.1",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.2",
-        "semver": "7.8.1",
-        "systeminformation": "5.31.7",
+        "semver": "7.8.5",
+        "systeminformation": "5.32.0",
         "tail": "2.2.6",
-        "tar": "7.5.15",
-        "tcp-port-used": "1.0.2",
-        "unzipper": "0.12.3"
+        "tar": "7.5.20",
+        "tcp-port-used": "1.0.3",
+        "unzipper": "0.12.5"
       },
       "bin": {
         "hb-service": "dist/bin/hb-service.js"
@@ -4032,7 +4097,7 @@
         "node": "^22.12.0 || ^24.0.0"
       },
       "optionalDependencies": {
-        "macos-temperature-sensor": "1.0.4",
+        "macos-temperature-sensor": "2.0.0",
         "osx-temperature-sensor": "1.0.8"
       }
     },
@@ -4047,9 +4112,9 @@
       }
     },
     "node_modules/homebridge-config-ui-x/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4085,9 +4150,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/homebridge-config-ui-x/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4283,12 +4348,13 @@
       }
     },
     "node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/ipaddr.js": {
@@ -4609,7 +4675,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -4653,14 +4720,15 @@
       }
     },
     "node_modules/is2": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
-      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+      "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
-        "ip-regex": "^4.1.0",
-        "is-url": "^1.2.4"
+        "ip-regex": "^2.1.0",
+        "is-url": "^1.2.2"
       },
       "engines": {
         "node": ">=v0.10.0"
@@ -5047,14 +5115,15 @@
       }
     },
     "node_modules/macos-temperature-sensor": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/macos-temperature-sensor/-/macos-temperature-sensor-1.0.4.tgz",
-      "integrity": "sha512-JROshGB+f+UnsbNwM6SER4AK82fdGmk79ElhH+8xVieCUQ1fxTanTwp7Rv9DTRtmgB6hLcEGvQYL8XsPbAKLUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-temperature-sensor/-/macos-temperature-sensor-2.0.0.tgz",
+      "integrity": "sha512-QPQx5LiKK2HMDYCyRhye1SoBBLeYeRcQQUrXS3TtT/Jk/kuKx66nEhsLM4TJSZcIVAtItU7BahRTkopm2Koh8g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -5580,9 +5649,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
-      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6651,9 +6720,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6781,9 +6850,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6880,9 +6949,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.32.6",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
-      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6890,9 +6959,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
-      "integrity": "sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.32.0.tgz",
+      "integrity": "sha512-7gfXs43T91miPxxTTtrYitotR/8MPsI2gy3XgUMs6kmOE/JCVqZp6nJpx4XkSutoSqDh6+Y2ovvb2A3RQCR+8w==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -6909,7 +6978,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",
@@ -6926,9 +6995,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6980,13 +7049,14 @@
       }
     },
     "node_modules/tcp-port-used": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.3.tgz",
+      "integrity": "sha512-4CEQ3qRJYo+mtEbJ+OoQu3dF4TDkwaO3RDVC4UzP5cpAOIUWwuwPjD7sdxDFFqsMUjsXVVYBMlg/boAaloThMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4.3.1",
-        "is2": "^2.0.6"
+        "is2": "2.0.1"
       }
     },
     "node_modules/tcp-port-used/node_modules/debug": {
@@ -6994,6 +7064,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7060,13 +7131,13 @@
       }
     },
     "node_modules/toad-cache": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
-      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/toidentifier": {
@@ -7282,17 +7353,32 @@
       }
     },
     "node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bluebird": "~3.7.2",
         "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "11.3.1",
         "graceful-fs": "^4.2.2",
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/uri-js": {
@@ -7444,9 +7530,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What changed

- update `form-data` to 4.0.6
- update the axios/config-UI dependency tree, including axios 1.18.1
- update `fast-uri` to 3.1.5
- update `socket.io-parser` to 4.2.7
- consolidate Dependabot PRs #158, #161, #165, and #166 into one release

## Why

These lockfile updates resolve the open CRLF injection, Axios request-construction, URI authority confusion, and Socket.IO memory-exhaustion advisories without changing application code or widening dependency ranges.

## Validation

- clean install under Node 24
- `npm run lint`
- `npm run build`
- `git diff --check`
